### PR TITLE
Fix includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ add_library(TonyRE.Code STATIC
 	"Code/Gel/Components/animationcomponent.h"
 	"Code/Gel/Components/avoidcomponent.cpp"
 	"Code/Gel/Components/avoidcomponent.h"
-	"Code/Gel/Components/bouncyComponent.cpp"
+	"Code/Gel/Components/bouncycomponent.cpp"
 	"Code/Gel/Components/BouncyComponent.h"
 	"Code/Gel/Components/CameraComponent.cpp"
 	"Code/Gel/Components/CameraComponent.h"

--- a/External/glad/CMakeLists.txt
+++ b/External/glad/CMakeLists.txt
@@ -2,6 +2,6 @@
 add_library(glad STATIC
 	"src/glad.c"
 	"include/glad/glad.h"
-	"include/khr/khrplatform.h"
+	"include/KHR/khrplatform.h"
 )
 target_include_directories(glad PUBLIC "include")


### PR DESCRIPTION
There were some includes with inconsistent case, therefore cmake fails to find them on some filesystems, such as ext4.