### PR TITLE
Add Win32/Unix configuration build checks and refactor variadics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,11 +791,18 @@ if(TRUE) # If WIN32
 	add_subdirectory("Wn32" EXCLUDE_FROM_ALL)
 	target_link_libraries(TonyRE.Code PUBLIC TonyRE.Wn32)
 
+	if(WIN32)
 	# Compile Win32 executable
 	add_executable(TonyRE WIN32
 		"Code/Sk/Main.cpp"
 		"Resources/Win32/THUG.rc"
 	)
+	else()
+		# Compile an executable
+		add_executable(TonyRE
+			"Code/Sk/Main.cpp"
+		)
+	endif()
 
 	target_link_libraries(TonyRE PUBLIC TonyRE.Common TonyRE.Code)
 

--- a/Code/Core/Debug/Messages.h
+++ b/Code/Core/Debug/Messages.h
@@ -121,17 +121,17 @@ inline void Dbg_Error( const char* A ... )		{ (void)A; };
 
 
 #ifdef	__NOPT_DEBUG__
-#define Dbg_Printf(A...)		{ printf(##A); 		}
-#define Dbg_Message(A...) 		{ Dbg::current_sig = &Dbg_signature; Dbg::message(##A);	}
-#define Dbg_Notify(A...) 		{ Dbg::current_sig = &Dbg_signature; Dbg::notify(##A);	}
-#define Dbg_Warning(A...) 		{ Dbg::current_sig = &Dbg_signature; Dbg::warning(##A);	}
-#define Dbg_Error(A...) 		{ Dbg::current_sig = &Dbg_signature; Dbg::error(##A);	}
+#define Dbg_Printf(...)		{ printf(__VA_ARGS__); 		}
+#define Dbg_Message(...) 		{ /*Dbg::current_sig = &Dbg_signature;*/ Dbg::message(__VA_ARGS__);	}
+#define Dbg_Notify(...) 		{ /*Dbg::current_sig = &Dbg_signature;*/ Dbg::notify(__VA_ARGS__);	}
+#define Dbg_Warning(...) 		{ /*Dbg::current_sig = &Dbg_signature;*/ Dbg::warning(__VA_ARGS__);	}
+#define Dbg_Error(...) 		{ /*Dbg::current_sig = &Dbg_signature;*/ Dbg::error(__VA_ARGS__);	}
 #else
-#define Dbg_Printf(A...)		{ printf(##A); 		}
-#define Dbg_Message(A...) 		{ Dbg::message(##A);	}
-#define Dbg_Notify(A...) 		{ Dbg::notify(##A);	}
-#define Dbg_Warning(A...) 		{ Dbg::warning(##A);	}
-#define Dbg_Error(A...) 		{ Dbg::error(##A);	}
+#define Dbg_Printf(...)		{ printf(__VA_ARGS__); 		}
+#define Dbg_Message(...) 		{ Dbg::message(__VA_ARGS__);	}
+#define Dbg_Notify(...) 		{ Dbg::notify(__VA_ARGS__);	}
+#define Dbg_Warning(...) 		{ Dbg::warning(__VA_ARGS__);	}
+#define Dbg_Error(...) 		{ Dbg::error(__VA_ARGS__);	}
 #endif
 
 #endif	// __PLAT_XBOX__

--- a/Wn32/CMakeLists.txt
+++ b/Wn32/CMakeLists.txt
@@ -125,8 +125,19 @@ add_library(TonyRE.Wn32 STATIC
 target_link_libraries(TonyRE.Wn32 PUBLIC TonyRE.Common)
 target_include_directories(TonyRE.Wn32 PUBLIC "Code")
 
-# Set platform defines
-target_compile_definitions(TonyRE.Wn32 PUBLIC __PLAT_WN32__)
+if(WIN32)
+	# Set platform defines
+	target_compile_definitions(TonyRE.Wn32 PUBLIC __PLAT_WN32__)
 
-# Link libraries
-target_link_libraries(TonyRE.Wn32 PUBLIC Ws2_32 SDL2-static glad glm)
+	# Link libraries
+	target_link_libraries(TonyRE.Wn32 PUBLIC Ws2_32 SDL2-static glad glm)
+endif()
+
+
+if (UNIX)
+	# Set platform defines
+	target_compile_definitions(TonyRE.Wn32 PUBLIC __PLAT_LINUX__)
+
+	# Link libraries
+	target_link_libraries(TonyRE.Wn32 PUBLIC SDL2-static glad glm)
+endif()


### PR DESCRIPTION
I added some platform checks to determine if build target is Win32 or Linux/Unix. Also, I replaced variadics in debug messages with some newer ones, so they build properly on Linux.