### PR TITLE
p_music.cpp: add safety check for GetSoundtrackNumSongs

### DIFF
--- a/Wn32/Code/Plat/Gel/Music/p_music.cpp
+++ b/Wn32/Code/Plat/Gel/Music/p_music.cpp
@@ -758,6 +758,11 @@ namespace Pcm
 	size_t GetSoundtrackNumSongs(size_t i)
 	{
 		const UserSoundtrack::Soundtracks &soundtracks = UserSoundtrack::GetSoundtracks();
+
+        if(soundtracks.empty()) {
+            return 0;
+        }
+
 		return soundtracks.at(i).tracks.size();
 	}
 


### PR DESCRIPTION
Added a little safety check to prevent the crash when there's no soundtracks