### PR TITLE
Debug.cpp: add current signature null check

### DIFF
--- a/Code/Core/Debug/Debug.cpp
+++ b/Code/Core/Debug/Debug.cpp
@@ -132,9 +132,11 @@ static void		s_prefixed_output( Level level, const char* text, va_list args )
 	}
 	
 #ifdef	__NOPT_DEBUG__
-	printf( "[%s] %s - ", 
-		s_typename[level], 
-		&current_sig->GetName());
+    if(current_sig) {
+        printf("[%s] %s - ",
+               s_typename[level],
+               &current_sig->GetName());
+    }
 #endif
 
 	vsprintf( printf_pad, text, args);


### PR DESCRIPTION
For some not known yet reasons current signature might be null, and that will lead to an obnoxious crash. I added a null check to prevent that from happening.